### PR TITLE
test(front): ajouter tests pour ItemEditForm

### DIFF
--- a/frontend/app/src/components/__test__/items/ItemEditForm.test.jsx
+++ b/frontend/app/src/components/__test__/items/ItemEditForm.test.jsx
@@ -1,0 +1,95 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fireEvent, waitFor, screen } from "@testing-library/react";
+import { renderWithRouter } from "@/test/test-utils.jsx";
+import ItemEditForm from "@/components/items/ItemEditForm";
+
+// ─── MOCK DES HOOKS ────────────────────────────────────────────────────────────
+vi.mock('@/hooks/useFetchData', () => ({
+    default: (url) => {
+        if (url === "/subcategories") {
+            return { data: [{ id: 3, name: "Mobilier" }], loading: false };
+        }
+        return { data: null, loading: false };
+    },
+}));
+
+vi.mock('@/hooks/useAuth', () => ({
+    default: () => ({
+        user: { id: 1 },
+        token: "fake-token",
+        isLoggedIn: true,
+        login: vi.fn(),
+        logout: vi.fn(),
+    }),
+}));
+
+vi.mock('@/hooks/useUploadImage', () => ({
+    default: () => ({
+        uploadImage: vi.fn(() => Promise.resolve("https://via.placeholder.com/300")),
+        loading: false,
+        imageUrl: "https://via.placeholder.com/300",
+        setImageUrl: vi.fn(),
+    }),
+}));
+
+describe("ItemEditForm", () => {
+    const mockOnSubmit = vi.fn();
+    const item = {
+        id: 42,
+        name: "Chaise",
+        description: "Une chaise sympa",
+        picture: "https://via.placeholder.com/300",
+        status: "Available",      // => affiché “Disponible”
+        subcategory_id: 3,
+    };
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("pré‑remplit bien les champs name, description, picture et status", () => {
+        renderWithRouter(
+            <ItemEditForm item={item} onSubmit={mockOnSubmit} loading={false} />
+        );
+
+        // Nom et description
+        expect(screen.getByDisplayValue("Chaise")).toBeInTheDocument();
+        expect(screen.getByDisplayValue("Une chaise sympa")).toBeInTheDocument();
+
+        // Aperçu de l'image
+        const img = screen.getByRole("img", { name: /preview/i });
+        expect(img).toHaveAttribute("src", item.picture);
+
+        // Statut (Available → “Disponible”)
+        expect(screen.getByDisplayValue(/disponible/i)).toBeInTheDocument();
+    });
+
+    it("appelle onSubmit AVEC uniquement name, description, picture et status modifiés", async () => {
+        renderWithRouter(
+            <ItemEditForm item={item} onSubmit={mockOnSubmit} loading={false} />
+        );
+
+        // Modifier le nom et le statut
+        fireEvent.change(screen.getByLabelText(/nom de l'objet/i), {
+            target: { value: "Chaise test" },
+        });
+        fireEvent.change(screen.getByLabelText(/statut/i), {
+            target: { value: "Unavailable" }, // “Indisponible”
+        });
+
+        // Soumettre
+        fireEvent.click(
+            screen.getByRole("button", { name: /mettre à jour/i })
+        );
+
+        await waitFor(() => {
+            expect(mockOnSubmit).toHaveBeenCalledWith({
+                name: "Chaise test",
+                description: "Une chaise sympa",
+                picture: "https://via.placeholder.com/300",
+                status: "Unavailable",
+            });
+        });
+    });
+});


### PR DESCRIPTION
### 📝 **Description complète :**

---

#### 🧪 Tests implémentés  
- 🎯 **Pré‑remplissage** des champs critiques :  
  - `name`  
  - `description`  
  - `picture` (aperçu via `<img alt="Preview" />`)  
  - `status` (“Disponible” pour `Available`)  
- 📝 **Soumission ciblée** :  
  - je modifie uniquement `name` et `status`  
  - je clique sur “Mettre à jour”  
  - j’affirme que `onSubmit` reçoit **seulement** `{ name, description, picture, status }`  

---

#### 🔧 Mocks & Setup  
- 🔌 **useFetchData** → simule `/subcategories` (retourne `[{ id: 3, name: "Mobilier" }]`)  
- 👤 **useAuth** → contexte minimum (user/token) pour éviter l’erreur “useAuth doit être utilisé dans un AuthProvider”  
- 📤 **useUploadImage** → upload simulé renvoyant immédiatement une URL  

---

#### 📂 Fichiers ajoutés  
- `src/components/__test__/items/ItemEditForm.test.jsx`

---

#### 🚧 Ce que je n’ai pas pu tester  
- 🗂️ **sélection réelle** de la sous‑catégorie dans le `<select>`  
- 📁 **upload de fichier** (champ `picture` en mode `<input type="file">`)  
- ⏳ **états de chargement** (`loading` / `subLoading`) et gestion des erreurs  
- ❌ **validation d’erreur** via le schéma Zod (`itemUpdateSchema`)  

---

✅ Tous les tests passent en local et la CI remonte ✅
![Capture d'écran 2025-04-17 055342](https://github.com/user-attachments/assets/aa786111-b2b1-404c-bf06-429cd7eb0887)
